### PR TITLE
Feature/backtester (#70)

### DIFF
--- a/kuo_test.ipynb
+++ b/kuo_test.ipynb
@@ -108,22 +108,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "# 指定 CSV 檔案路徑\n",
-    "file_path = BACKTEST_RESULT_DIR_PATH / \"Momentum\" / \"Momentum_trading_report.csv\"\n",
-    "# 讀取 CSV 檔案\n",
-    "df = pd.read_csv(file_path)\n",
-    "\n",
-    "df.head(-10)\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -140,10 +124,8 @@
     "\n",
     "start_date = datetime.date(2025, 8, 1)\n",
     "end_date = datetime.date(2025, 8, 31)\n",
-    "stock_id = \"2330\"\n",
-    "price = StockPriceAPI()\n",
-    "df = price.get_range(start_date, end_date)\n",
-    "df.head(3)"
+    "stock_id = \"0050\"\n",
+    "price = StockPriceAPI()"
    ]
   },
   {
@@ -151,10 +133,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "d = MarketCalendar.get_last_trading_date(price, datetime.date(2025, 8, 31))\n",
-    "d"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -162,13 +141,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "start_date = '2025-08-01'\n",
-    "end_date = '2025-08-29'\n",
-    "result_1 = df.loc[(df['date'] == start_date) & (df['stock_id'] == '0050')]\n",
-    "result_2 = df.loc[(df['date'] == end_date) & (df['stock_id'] == '0050')]\n",
+    "start_date = datetime.date(2020, 5, 1)\n",
+    "end_date = datetime.date(2020, 5, 30)\n",
+    "close_price: pd.DataFrame = price.get_stock_price(\n",
+    "    stock_id=stock_id,\n",
+    "    start_date=start_date,\n",
+    "    end_date=end_date,\n",
+    ")\n",
     "\n",
+    "roi = close_price['收盤價'].iloc[-1] / close_price['收盤價'].iloc[0] - 1\n",
+    "roi\n",
     "\n",
-    "print(f\"0050 ROI: {round(result_2['收盤價'].iloc[0] / result_1['收盤價'].iloc[0] - 1, 3) * 100}%\")"
+    "\n"
    ]
   },
   {
@@ -177,9 +161,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "date = datetime.date(2025, 8, 29)\n",
-    "df = price.get(date)\n",
-    "df.empty"
+    "a = close_price.cummax()\n",
+    "a"
    ]
   },
   {

--- a/trader/backtest/report/base.py
+++ b/trader/backtest/report/base.py
@@ -42,6 +42,11 @@ class BaseBacktestReporter(ABC):
         pass
 
     @abstractmethod
+    def plot_everyday_profit(self) -> None:
+        """計算並繪製每天的利潤"""
+        pass
+
+    @abstractmethod
     def set_figure_config(self, *args, **kwargs) -> None:
         """設置繪圖配置"""
         pass

--- a/trader/managers/stock/position/base.py
+++ b/trader/managers/stock/position/base.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+
+"""
+Abstract base class for all position managers.
+"""
+
+
+class BasePositionManager(ABC):
+    """Base Class of Position Manager"""
+
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def setup(self, *args, **kwargs) -> None:
+        """Set Up the Config of Position Manager"""
+        pass
+
+    @abstractmethod
+    def open_position(self, *args, **kwargs) -> None:
+        """Open Position"""
+        pass
+
+    @abstractmethod
+    def close_position(self, *args, **kwargs) -> None:
+        """Close Position"""
+        pass

--- a/trader/managers/stock/position/position_manager.py
+++ b/trader/managers/stock/position/position_manager.py
@@ -1,0 +1,226 @@
+from typing import List, Optional
+
+from loguru import logger
+
+from trader.managers.stock.position.base import BasePositionManager
+from trader.models import StockAccount, StockOrder, StockPosition, StockTradeRecord
+from trader.utils import Action, PositionType
+from trader.utils.instrument import StockUtils
+
+
+class StockPositionManager(BasePositionManager):
+    """Stock Position Manager"""
+
+    def __init__(self, account: StockAccount):
+        super().__init__()
+        self.account: StockAccount = account
+
+    def setup(self, *args, **kwargs) -> None:
+        """Set Up the Config of Stock Position Manager"""
+        pass
+
+    def open_position(self, stock_order: StockOrder) -> Optional[StockPosition]:
+        """
+        - Description: 開倉下單股票
+        - Parameters:
+            - stock: StockOrder
+                目標股票的訂單資訊
+        - Return:
+            - position: StockPosition
+        """
+        # Calculate position value
+        position_value: float = self.calculate_position_value(
+            price=stock_order.price,
+            volume=stock_order.volume,
+        )
+
+        # Create position
+        position: Optional[StockPosition] = None
+
+        # Open Long & Buy Position
+        if (
+            stock_order.position_type == PositionType.LONG
+            and stock_order.action == Action.BUY
+        ):
+            # Calculate open commission & tax & total open cost
+            open_commission: int = StockUtils.calculate_transaction_commission(
+                price=stock_order.price,
+                volume=stock_order.volume,
+            )
+            open_tax: int = 0
+            open_cost: int = open_commission + open_tax
+
+            # Check if the account has enough balance
+            if self.account.balance >= position_value + open_cost:
+                logger.info(f"* Place Open Order: {stock_order.stock_id}")
+
+                position = StockPosition(
+                    id=self.account.generate_trade_id(),
+                    stock_id=stock_order.stock_id,
+                    is_closed=False,
+                    position_type=stock_order.position_type,
+                    date=stock_order.date,
+                    price=stock_order.price,
+                    volume=stock_order.volume,
+                    commission=open_commission,
+                    tax=open_tax,
+                    transaction_cost=open_cost,
+                    unrealized_pnl=0,
+                    unrealized_roi=0,
+                )
+
+                self.account.balance -= position_value + open_cost
+                self.account.positions.append(position)
+        # Open Short & Sell Position
+        elif (
+            stock_order.position_type == PositionType.SHORT
+            and stock_order.action == Action.SELL
+        ):
+            pass
+        return position
+
+    def close_position(self, stock_order: StockOrder) -> List[StockTradeRecord]:
+        """
+        - Description: 下單平倉股票（支援 FIFO 拆倉與部分平倉）
+        - Parameters:
+            - stock_order: StockOrder
+                目標股票的訂單資訊
+        - Return:
+            - closed_positions: List[StockTradeRecord]
+                實際被平倉的所有倉位（可能為多筆）
+        """
+
+        # 要平倉的倉位 List
+        close_positions: List[StockTradeRecord] = []
+
+        # 從帳戶抓出所有該股票未平倉的倉位（FIFO）
+        open_positions: List[StockPosition] = [
+            p
+            for p in self.account.positions
+            if p.stock_id == stock_order.stock_id and not p.is_closed
+        ]
+
+        # Calculate remaining close volume
+        remaining_close_volume: int = stock_order.volume
+
+        for position in open_positions:
+            if remaining_close_volume <= 0:
+                break
+
+            # Sell Long Position
+            if (
+                position.position_type == PositionType.LONG
+                and stock_order.action == Action.SELL
+            ):
+                # 這筆 position 要平倉的數量
+                close_volume: int = min(position.volume, remaining_close_volume)
+
+                logger.info(
+                    f"* Place Close Order: {stock_order.stock_id} ({close_volume} lots)"
+                )
+
+                # Calculate position value
+                position_value: float = self.calculate_position_value(
+                    price=stock_order.price,
+                    volume=close_volume,
+                )
+
+                # Calculate sell commission & tax & total close cost
+                sell_commission: int = StockUtils.calculate_transaction_commission(
+                    price=stock_order.price,
+                    volume=close_volume,
+                )
+                sell_tax: int = StockUtils.calculate_transaction_tax(
+                    stock_order.price,
+                    close_volume,
+                )
+
+                # Calculate proportional buy commission & total_transaction_cost
+                proportional_buy_commission: int = int(
+                    position.commission * (close_volume / position.volume)
+                )
+                total_transaction_cost: int = (
+                    proportional_buy_commission + sell_commission + sell_tax
+                )
+
+                # Create stock trade record
+                record: StockTradeRecord = StockTradeRecord(
+                    id=position.id,
+                    stock_id=position.stock_id,
+                    is_closed=True,
+                    position_type=position.position_type,
+                    buy_date=position.date,
+                    buy_price=position.price,
+                    buy_volume=close_volume,
+                    sell_date=stock_order.date,
+                    sell_price=stock_order.price,
+                    sell_volume=close_volume,
+                    commission=proportional_buy_commission + sell_commission,
+                    tax=sell_tax,
+                    transaction_cost=total_transaction_cost,
+                    realized_pnl=StockUtils.calculate_net_profit(
+                        buy_price=position.price,
+                        sell_price=stock_order.price,
+                        volume=close_volume,
+                    ),
+                    roi=StockUtils.calculate_roi(
+                        buy_price=position.price,
+                        sell_price=stock_order.price,
+                        volume=close_volume,
+                    ),
+                )
+
+                # Update position
+                position.volume -= close_volume
+                position.commission -= proportional_buy_commission
+                position.transaction_cost -= proportional_buy_commission
+                if position.volume == 0:
+                    position.is_closed = True
+
+                # Update account
+                self.account.balance += position_value - total_transaction_cost
+                self.account.realized_pnl += record.realized_pnl
+                self.account.trade_records.append(record)
+
+                close_positions.append(record)
+                remaining_close_volume -= close_volume
+
+            # Sell Short Position
+            elif (
+                position.position_type == PositionType.SHORT
+                and stock_order.action == Action.BUY
+            ):
+                logger.info(
+                    f"* Place Close Order: {stock_order.stock_id} ({close_volume} lots)"
+                )
+                pass
+
+        if remaining_close_volume > 0:
+            logger.warning(
+                f"[Close Position] Not enough holdings to close {stock_order.volume} lots of {stock_order.stock_id}, "
+                f"only closed {stock_order.volume - remaining_close_volume} lots"
+            )
+            # 📌 業界常見做法：
+            # ✔ 不會在 close_position() 內自動開空單（避免混淆職責）
+            # ✔ 僅記錄已平倉的部分，對剩餘張數給出警告或拋出錯誤
+            # ✔ 是否將剩餘張數視為新開空單，由上層策略層決定
+            # 👉 若要嚴格限制，可改為 raise ValueError("Insufficient holdings to close position")
+
+        # Remove closed positions
+        self.account.remove_closed_positions()
+
+        return close_positions
+
+    def calculate_position_value(self, price: float, volume: int) -> float:
+        """
+        - Description: 計算股票部位價值
+        - Parameters:
+            - price: float
+                股票價格
+            - volume: int
+                股票張數
+        - Return:
+            - position_value: float
+                股票部位價值
+        """
+        return price * StockUtils.convert_lot_to_share(volume)

--- a/trader/models/__init__.py
+++ b/trader/models/__init__.py
@@ -1,1 +1,8 @@
-from .stock import StockAccount, StockOrder, StockQuote, StockTradeRecord, TickQuote
+from .stock import (
+    StockAccount,
+    StockOrder,
+    StockPosition,
+    StockQuote,
+    StockTradeRecord,
+    TickQuote,
+)

--- a/trader/models/stock/__init__.py
+++ b/trader/models/stock/__init__.py
@@ -1,4 +1,5 @@
 from .account import StockAccount
 from .order import StockOrder
+from .position import StockPosition
 from .quote import StockQuote, TickQuote
 from .record import StockTradeRecord

--- a/trader/models/stock/order.py
+++ b/trader/models/stock/order.py
@@ -1,6 +1,6 @@
 import datetime
 
-from trader.utils import PositionType
+from trader.utils import Action, PositionType
 
 """
 This module defines the structure for stock orders used in the backtesting phase,
@@ -13,17 +13,19 @@ class StockOrder:
 
     def __init__(
         self,
-        stock_id: str = "",
-        date: datetime.datetime = None,
-        price: float = 0.0,
-        volume: int = 0,  # Unit: Lot
-        position_type: PositionType = PositionType.LONG,
+        stock_id: str = "",  # 股票代號
+        date: datetime.datetime = None,  # 交易日期（Tick會是Timestamp）
+        action: Action = Action.BUY,  # 訂單動作（Buy / Sell）
+        position_type: PositionType = PositionType.LONG,  # 持倉方向（Long / Short）
+        price: float = 0.0,  # 交易價位
+        volume: int = 0,  # 交易張數（Unit: Lot）
     ):
         # Basic Info
-        self.stock_id: str = stock_id  # 股票代號
-        self.date: datetime.datetime = date  # 交易日期（Tick會是Timestamp）
+        self.stock_id: str = stock_id
+        self.date: datetime.datetime = date
 
         # Order Info
-        self.price: float = price  # 交易價位
-        self.volume: int = volume  # 交易張數（Unit: Lot）
-        self.position_type: PositionType = position_type  # 持倉方向（Long or Short）
+        self.action: Action = action
+        self.position_type: PositionType = position_type
+        self.price: float = price
+        self.volume: int = volume

--- a/trader/models/stock/position.py
+++ b/trader/models/stock/position.py
@@ -1,0 +1,42 @@
+import datetime
+
+from trader.utils import PositionType
+
+
+class StockPosition:
+    """庫存未平倉倉位資訊"""
+
+    def __init__(
+        self,
+        id: int = 0,
+        stock_id: str = "",
+        is_closed: bool = False,
+        position_type: PositionType = PositionType.LONG,
+        date: datetime.date = None,
+        price: float = 0.0,
+        volume: int = 0,
+        commission: float = 0.0,
+        tax: float = 0.0,
+        transaction_cost: float = 0.0,
+        unrealized_pnl: float = 0.0,
+        unrealized_roi: float = 0.0,
+    ):
+        # Basic Info
+        self.id: int = id  # 倉位編號（每筆倉位唯一編號）
+        self.stock_id: str = stock_id  # 股票代號
+        self.is_closed: bool = is_closed  # 是否已經平倉
+        self.position_type: PositionType = position_type  # 持倉方向（Long or Short）
+
+        # Position Info
+        self.date: datetime.date = date  # 開倉日期
+        self.price: float = price  # 開倉價位
+        self.volume: int = volume  # 開倉張數
+
+        # Transaction Costs
+        self.commission: float = commission  # 開倉手續費
+        self.tax: float = tax  # 開倉交易稅
+        self.transaction_cost: float = transaction_cost  # 開倉交易成本
+
+        # Transaction Performance （以後再寫更新未實現損益的函數）
+        self.unrealized_pnl: float = unrealized_pnl  # 未實現損益
+        self.unrealized_roi: float = unrealized_roi  # 未實現報酬率

--- a/trader/utils/instrument.py
+++ b/trader/utils/instrument.py
@@ -64,7 +64,7 @@ class StockUtils:
         return round((cur_close_price / prev_close_price - 1) * 100, 2)
 
     @staticmethod
-    def convert_share_to_lot(shares: float) -> int:
+    def convert_share_to_lot(shares: int) -> int:
         """
         - Description: 將股數轉換為張數
         - Parameters:
@@ -90,15 +90,15 @@ class StockUtils:
         return int(lots * Units.LOT)
 
     @staticmethod
-    def calculate_transaction_commission(price: float, volume: float) -> int:
+    def calculate_transaction_commission(price: float = 0.0, volume: int = 0) -> int:
         """
         - Description:
             計算股票買賣時的手續費
         - Parameters:
             - price: float
                 成交價格
-            - volume: float
-                成交股數（Unit: Shares）
+            - volume: int
+                成交張數（Unit: Lots）
         - Return:
             - commission: int
                 手續費
@@ -109,19 +109,24 @@ class StockUtils:
         """
         return max(
             Commission.MinFee,
-            int(price * volume * Commission.CommRate * Commission.Discount),
+            int(
+                price
+                * StockUtils.convert_lot_to_share(volume)
+                * Commission.CommRate
+                * Commission.Discount
+            ),
         )
 
     @staticmethod
-    def calculate_transaction_tax(price: float, volume: float) -> int:
+    def calculate_transaction_tax(price: float = 0.0, volume: int = 0) -> int:
         """
         - Description:
             計算股票賣出時的交易稅
         - Parameters:
             - price: float
                 成交價格
-            - volume: float
-                成交股數（Unit: Shares）
+            - volume: int
+                成交張數（Unit: Lots）
         - Return:
             - tax: int
                 交易稅
@@ -129,13 +134,15 @@ class StockUtils:
             For long position, the tax cost:
             - sell tax (券賣證交稅 = 成交價 x 成交股數 x 證交稅率)
         """
-        return max(1, int(price * volume * Commission.TaxRate))
+        return max(
+            1, int(price * StockUtils.convert_lot_to_share(volume) * Commission.TaxRate)
+        )
 
     @staticmethod
     def calculate_transaction_cost(
-        buy_price: float,
-        sell_price: float,
-        volume: float,
+        buy_price: float = 0.0,
+        sell_price: float = 0.0,
+        volume: int = 0,
     ) -> Tuple[int, int]:
         """
         - Description:
@@ -145,8 +152,8 @@ class StockUtils:
                 股票買入價格
             - sell_price: float
                 股票賣出價格
-            - volume: float
-                股數（Unit: Shares）
+            - volume: int
+                成交張數（Unit: Lots）
         - Return:
             - buy_transaction_cost: int
                 買入交易成本
@@ -161,18 +168,18 @@ class StockUtils:
 
         # 買入 & 賣出的交易成本
         buy_transaction_cost: int = StockUtils.calculate_transaction_commission(
-            buy_price, volume
+            price=buy_price, volume=volume
         )
-        sell_transaction_cost: float = StockUtils.calculate_transaction_commission(
-            sell_price, volume
-        ) + StockUtils.calculate_transaction_tax(sell_price, volume)
+        sell_transaction_cost: int = StockUtils.calculate_transaction_commission(
+            price=sell_price, volume=volume
+        ) + StockUtils.calculate_transaction_tax(price=sell_price, volume=volume)
         return (buy_transaction_cost, sell_transaction_cost)
 
     @staticmethod
     def calculate_net_profit(
         buy_price: float,
         sell_price: float,
-        volume: float,
+        volume: int,
     ) -> float:
         """
         - Description: 計算股票交易的淨收益（扣除手續費和交易稅）（目前只有做多）
@@ -181,18 +188,20 @@ class StockUtils:
                 股票買入價格
             - sell_price: float
                 股票賣出價格
-            - volume: float
-                股數（Unit: Shares）
+            - volume: int
+                成交張數（Unit: Lots）
         - Return:
             - profit: float
         """
 
-        buy_value: float = buy_price * volume
-        sell_value: float = sell_price * volume
+        buy_value: float = buy_price * StockUtils.convert_lot_to_share(volume)
+        sell_value: float = sell_price * StockUtils.convert_lot_to_share(volume)
 
         # 買入 & 賣出手續費
         buy_comm, sell_comm = StockUtils.calculate_transaction_cost(
-            buy_price, sell_price, volume
+            buy_price=buy_price,
+            sell_price=sell_price,
+            volume=volume,
         )
 
         profit: float = (sell_value - buy_value) - (buy_comm + sell_comm)
@@ -202,7 +211,7 @@ class StockUtils:
     def calculate_roi(
         buy_price: float,
         sell_price: float,
-        volume: float,
+        volume: int,
     ) -> float:
         """
         - Description: 計算股票投資報酬率（ROI）（目前只有做多）
@@ -211,16 +220,18 @@ class StockUtils:
                 股票買入價格
             - sell_price: float
                 股票賣出價格
-            - volume: float
-                股數（Unit: Shares）
+            - volume: int
+                成交張數（Unit: Lots）
         - Return:
             - roi: float
                 投資報酬率（%）
         """
 
-        buy_value: float = buy_price * volume
+        buy_value: float = buy_price * StockUtils.convert_lot_to_share(volume)
         buy_comm, _ = StockUtils.calculate_transaction_cost(
-            buy_price, sell_price, volume
+            buy_price=buy_price,
+            sell_price=sell_price,
+            volume=volume,
         )
 
         # 計算投資成本
@@ -229,7 +240,9 @@ class StockUtils:
             return 0.0
 
         roi: float = (
-            StockUtils.calculate_net_profit(buy_price, sell_price, volume)
+            StockUtils.calculate_net_profit(
+                buy_price=buy_price, sell_price=sell_price, volume=volume
+            )
             / investment_cost
         ) * 100
         return round(roi, 2)


### PR DESCRIPTION
* Add get_next_trade_id in StockAccount

* Rename get_trade_id -> generate_trade_id

* Refator StockUtils (Unit in shares -> Lots)

* Black .

* Add attribute action in StockOrder

* 1. Add position.py in models/
2. Add position_manager.py in managers/

* 1. Refactor place_open_order & place_close_order in Backtester
2. Add base.py & position_manager.py in managers/
3. Refactor account.py and position.py

* Refactor close_position in StockPositionManager

* Remove place_open_order and place_close_order

* Refactor generate_trading_report in StockBacktestReporter

* Refactor plot_balance_curve in StockBacktestReporter

* Fix a bug in MomentumStrategy

* Fix a bug in MomentumStrategy

* Fix a bug in StockPositionManager

* Fix a bug in MomentumStrategy

* Add init_row in plot_balance_curve

* Black .

* Add plot_everyday_profit method in StockBacktestReporter

* Add plot_balance_mdd in StockBacktestReporter

* 1. Add plot_balance_and_benchmark_curve method in StockBacktestReporter
2. Add self.benchmark_price in StockBacktestReporter

* feat(report): add origin_date and include initial capital point in net worth plot

- Added `self.origin_date` (start_date - 1 day) as a virtual initial point for plotting
- Modified `plot_balance_and_benchmark_curve` to prepend initial capital at `origin_date`
- Ensured both strategy and benchmark net worth curves start from the same initial capital
- Verified ROI calculation:
  - Strategy ROI = (final_balance / init_capital - 1)
  - Benchmark ROI = (final_price / start_price - 1)
- Improves visual clarity and aligns with industry practice for backtest equity curves

* Add some comments in StockBacktestReporter

* Update some comments