### PR TITLE
docs(readme): split venv create and activate comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ graph TB
 ### Option 1: Local venv + requirements.txt
 
 ```bash
-# create and activate virtualenv
+# create virtualenv
 python3 -m venv .venv
+# activate virtualenv
 source .venv/bin/activate
 
 # install dependencies

--- a/README_zh.md
+++ b/README_zh.md
@@ -90,8 +90,9 @@ graph TB
 ### 方式 1：本機 venv + requirements.txt
 
 ```bash
-# 建立並啟用虛擬環境
+# 建立虛擬環境
 python3 -m venv .venv
+# 啟用虛擬環境
 source .venv/bin/activate
 
 # 安裝相依套件


### PR DESCRIPTION
Replace the single combined comment above the venv block with two lines: one for `python3 -m venv .venv` and one for `source .venv/bin/activate`, in both English and Chinese READMEs, so each command has a matching explanation.

Made-with: Cursor